### PR TITLE
Document methods that return (supposedly) read-only references.

### DIFF
--- a/src/biocutils/Factor.py
+++ b/src/biocutils/Factor.py
@@ -159,6 +159,9 @@ class Factor:
         Returns:
             Array of integer codes, used as indices into the levels from
             :py:meth:`~get_levels`. Missing values are marked with -1.
+
+            This should be treated as a read-only reference. To modify
+            the codes, use :py:meth:`~set_codes` instead.
         """
         return self._codes
 
@@ -193,6 +196,9 @@ class Factor:
         """
         Returns:
             List of strings containing the factor levels.
+
+            This should be treated as a read-only reference. To modify the
+            levels, use :py:meth:`~set_levels` instead.
         """
         return self._levels
 
@@ -234,6 +240,9 @@ class Factor:
         """
         Returns:
             Names for the factor elements.
+
+            This should be treated as a read-only reference. To modify the
+            names, use :py:meth:`~set_names` instead.
         """
         return self._names
 

--- a/src/biocutils/NamedList.py
+++ b/src/biocutils/NamedList.py
@@ -118,6 +118,9 @@ class NamedList:
         """
         Returns:
             Names for the list elements.
+
+            The returned object should be treated as a read-only reference. To
+            modify the names, use :py:meth:`~set_names` instead.
         """
         return self._names
 
@@ -470,6 +473,8 @@ class NamedList:
         """
         Returns:
             The underlying list of elements.
+
+            The returned object should be treated as a read-only reference.
         """
         return self._data
 
@@ -478,6 +483,8 @@ class NamedList:
         Returns:
             A dictionary where the keys are the names and the values are the
             list elements. Only the first occurrence of each name is returned.
+
+            Values of the dictionary should be treated as read-only references.
         """
         output = {}
         for i, n in enumerate(self._names):

--- a/src/biocutils/Names.py
+++ b/src/biocutils/Names.py
@@ -98,6 +98,9 @@ class Names:
         """
         Returns:
             List of strings containing the names.
+
+            This should be treated as a read-only reference. Modifications
+            should be performed by creating a new ``Names`` object instead.
         """
         return self._names
 


### PR DESCRIPTION
Closes #18.